### PR TITLE
feat(pet): add Inbox tab to pet panel with persisted notifications

### DIFF
--- a/apps/desktop/src/components/pet/PetInbox.tsx
+++ b/apps/desktop/src/components/pet/PetInbox.tsx
@@ -1,0 +1,117 @@
+// Inbox tab for the pet-panel window (PRD: pet inbox).
+//
+// Lists notifications received via `pet://notify` and captured by
+// `petNotifyDispatcher.dispatchNotification` into `petStore.inboxItems`.
+// Each row mirrors what the bubble/corner toast showed, and re-fires the
+// same jump on click via `pet://bubble-action` (the MAIN window's jump
+// router handles it exactly like a bubble title-click).
+//
+// State is persisted to `settings:all` and synced to the pet-panel window
+// via the shared `pet://settings-updated` channel — no separate IPC needed.
+
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePetStore, type InboxItem } from '@/store/petStore';
+import type { PetBubbleActionEvent } from './PetBubbleApp';
+
+/** Format a receivedAt epoch ms as a locale-aware string. Kept tiny — no
+ *  relative-time library, no i18n key. ponytail: yagni on relative time. */
+function formatTime(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+/** Fire the same `pet://bubble-action` event the bubble window emits on
+ *  title-click. The main-window jump router handles target.kind routing
+ *  (schedule / chat / task / file). `launch` payloads route via type
+ *  'launch' instead. */
+async function fireAction(event: PetBubbleActionEvent) {
+  try {
+    const { emit } = await import('@tauri-apps/api/event');
+    await emit('pet://bubble-action', event);
+  } catch {
+    // Non-tauri (tests) — non-fatal.
+  }
+}
+
+/** A single inbox row. Click re-fires the payload's jump. */
+function InboxRow({ item }: { item: InboxItem }) {
+  const { t } = useTranslation();
+  const { payload } = item;
+  const onClick = useCallback(() => {
+    if (payload.target) {
+      void fireAction({
+        type: 'navigate',
+        target: payload.target,
+        source: payload.source,
+      });
+    } else if (payload.launch) {
+      void fireAction({
+        type: 'launch',
+        target: payload.target,
+        source: payload.source,
+        launch: payload.launch,
+      });
+    }
+  }, [payload]);
+
+  const kind = payload.kind ?? 'info';
+  const title = payload.title ?? payload.source ?? '';
+  const clickable = Boolean(payload.target || payload.launch);
+  const kindLabel = t(`pet:inbox.kind.${kind}`, { defaultValue: kind });
+
+  return (
+    <button
+      type="button"
+      className={`pet-inbox-row${clickable ? ' is-clickable' : ''}`}
+      onClick={onClick}
+      disabled={!clickable}
+    >
+      <div className="pet-inbox-row-head">
+        {kind !== 'info' && (
+          <span className={`pet-inbox-kind pet-inbox-kind--${kind}`}>{kindLabel}</span>
+        )}
+        {title && <span className="pet-inbox-title">{title}</span>}
+        <span className="pet-inbox-time">{formatTime(item.receivedAt)}</span>
+      </div>
+      {payload.text && <div className="pet-inbox-text">{payload.text}</div>}
+    </button>
+  );
+}
+
+export function PetInbox(): JSX.Element {
+  const { t } = useTranslation();
+  const items = usePetStore((s) => s.inboxItems);
+  const clearInbox = usePetStore((s) => s.clearInbox);
+
+  if (items.length === 0) {
+    return (
+      <div className="pet-inbox-empty">
+        {t('pet:inbox.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="pet-inbox">
+      <div className="pet-inbox-toolbar">
+        <span className="pet-inbox-count">{items.length}</span>
+        <button
+          type="button"
+          className="pet-inbox-clear"
+          onClick={() => clearInbox()}
+        >
+          {t('pet:inbox.clear')}
+        </button>
+      </div>
+      <div className="pet-inbox-list">
+        {items.map((item) => (
+          <InboxRow key={item.id} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/pet/PetPanelApp.tsx
+++ b/apps/desktop/src/components/pet/PetPanelApp.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { isTauri } from '@/utils/platform';
 import { usePetStore } from '@/store/petStore';
+import { hydrateAllStores } from '@/store/settingsPersistence';
 import {
   clampPanelPosition,
   computePanelPosition,
@@ -10,8 +12,9 @@ import {
 } from './petPosition';
 import { PetLauncher } from './PetLauncher';
 import { PetChat } from './PetChat';
+import { PetInbox } from './PetInbox';
 
-type PetPanelTab = 'actions' | 'chat';
+type PetPanelTab = 'actions' | 'chat' | 'inbox';
 
 interface PetCursorProbeResult {
   cursor_x: number;
@@ -72,6 +75,7 @@ export function PetPanelApp() {
   // flips `is-visible` on → CSS transitions opacity 0→1 + scale 0.98→1 over
   // 180ms from the stable final frame.
   const [isVisible, setVisible] = useState(false);
+  const { t } = useTranslation();
   const setPetPanelPosition = usePetStore((s) => s.setPetPanelPosition);
   const setPetPanelSize = usePetStore((s) => s.setPetPanelSize);
 
@@ -146,6 +150,36 @@ export function PetPanelApp() {
         });
       } catch (err) {
         console.warn('[pet-panel] panel-fade-in listener failed:', err);
+      }
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  // ── Cross-window settings sync ──
+  // The panel window holds its own petStore instance; without this listener
+  // it would never see writes from the main window (e.g. `addInboxItem` on
+  // `pet://notify`) because those only update the main window's store and
+  // broadcast via `pet://settings-updated`. Mirrors the listener in
+  // PetBubbleApp / PetCornerApp — same channel, same `hydrateAllStores` call.
+  // Without this, the Inbox tab stays empty even after a curl triggers a
+  // notification: the main window recorded the item, but the panel's
+  // petStore.inboxItems was never updated.
+  useEffect(() => {
+    if (!isTauri()) return;
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen<Record<string, unknown>>(
+          'pet://settings-updated',
+          (event) => {
+            if (event.payload) hydrateAllStores(event.payload);
+          },
+        );
+      } catch (err) {
+        console.warn('[pet-panel] settings-updated listener failed:', err);
       }
     })();
     return () => {
@@ -427,7 +461,7 @@ export function PetPanelApp() {
             className={`pet-panel-tab${tab === 'chat' ? ' is-active' : ''}`}
             onClick={() => setTab('chat')}
           >
-            Chat
+            {t('pet:tabs.chat')}
           </button>
           <button
             type="button"
@@ -436,7 +470,16 @@ export function PetPanelApp() {
             className={`pet-panel-tab${tab === 'actions' ? ' is-active' : ''}`}
             onClick={() => setTab('actions')}
           >
-            Actions
+            {t('pet:tabs.actions')}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'inbox'}
+            className={`pet-panel-tab${tab === 'inbox' ? ' is-active' : ''}`}
+            onClick={() => setTab('inbox')}
+          >
+            {t('pet:tabs.inbox')}
           </button>
         </nav>
         <button
@@ -450,7 +493,7 @@ export function PetPanelApp() {
         </button>
       </header>
       <main className="pet-panel-body">
-        {tab === 'chat' ? <PetChat /> : <PetLauncher />}
+        {tab === 'chat' ? <PetChat /> : tab === 'actions' ? <PetLauncher /> : <PetInbox />}
       </main>
     </div>
   );

--- a/apps/desktop/src/components/pet/pet.css
+++ b/apps/desktop/src/components/pet/pet.css
@@ -361,6 +361,118 @@ html.is-pet-panel-window body {
   font-size: 13px;
 }
 
+/* ── Inbox tab ──
+ * Scrollable list of received-notification snapshots. Each row is a button
+ * that re-fires the original payload's jump. Toolbar holds a count + Clear. */
+.pet-inbox {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+}
+.pet-inbox-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--t2, #5a6275);
+}
+.pet-inbox-clear {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--brd, #e2e5ee);
+  border-radius: 6px;
+  color: var(--t2, #5a6275);
+  font-family: inherit;
+  font-size: 11px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.pet-inbox-clear:hover {
+  background: var(--hov, #eef0f5);
+  color: var(--t1, #1f2330);
+}
+.pet-inbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow: auto;
+  min-height: 0;
+  padding-right: 2px;
+}
+.pet-inbox-row {
+  appearance: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--brd, #e2e5ee);
+  border-radius: 8px;
+  background: var(--panel, #ffffff);
+  color: var(--t1, #1f2330);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: default;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.pet-inbox-row.is-clickable {
+  cursor: pointer;
+}
+.pet-inbox-row.is-clickable:hover {
+  background: var(--hov, #eef0f5);
+  border-color: var(--acc, #3a6ef0);
+}
+.pet-inbox-row:disabled {
+  cursor: default;
+  color: var(--t2, #5a6275);
+}
+.pet-inbox-row-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+.pet-inbox-title {
+  flex: 1;
+  font-weight: 600;
+  color: var(--t1, #1f2330);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pet-inbox-time {
+  color: var(--t3, #8a92a3);
+  font-size: 10px;
+  white-space: nowrap;
+}
+.pet-inbox-kind {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--hov, #eef0f5);
+  color: var(--t2, #5a6275);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.pet-inbox-text {
+  color: var(--t2, #5a6275);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.pet-inbox-empty {
+  color: var(--t3, #8a92a3);
+  font-size: 13px;
+  padding: 24px 0;
+  text-align: center;
+}
+
 /* ── Launcher grid (PR2) ──
  * 8 buttons in a 2-column × 4-row grid. Each button is a vertical stack of
  * icon + label. Fits the 600×840 panel with room below for the chat slot. */

--- a/apps/desktop/src/components/settings/BubbleTemplateAIChatModal.tsx
+++ b/apps/desktop/src/components/settings/BubbleTemplateAIChatModal.tsx
@@ -9,6 +9,7 @@ import { useAiConfigStore } from '@/store/aiConfigStore';
 import { useModelRegistryStore } from '@/store/modelRegistryStore';
 import { findModelInCatalog } from '@/services/modelRegistry/loader';
 import { isVisionModel } from '@/services/modelRegistry/merge';
+import type { Model } from '@/services/modelRegistry/types';
 import { useBubbleTemplateChatStore } from '@/store/bubbleTemplateChatStore';
 import { generateId } from '@/utils/idGenerator';
 import { extractLastJsonFence } from '@/components/pet/extractLastJsonFence';
@@ -65,6 +66,12 @@ function readChatConfig(): ChatConfig | null {
  *  Returning this constant keeps the not-found path referentially stable. */
 const EMPTY_MESSAGES: CliMessage[] = [];
 
+/** Same pitfall as EMPTY_MESSAGES: `s.modelsByProvider[chatProvider] ?? []`
+ *  creates a new array on every selector call when the provider has no
+ *  fetched models yet, which sends useSyncExternalStore into an infinite
+ *  re-render loop. Return this constant instead. */
+const EMPTY_MODELS: Model[] = [];
+
 
 /** Read an image File into {data, mediaType, previewUrl} via FileReader. */
 function readImageFile(file: File): Promise<{ data: string; mediaType: string; previewUrl: string }> {
@@ -118,7 +125,7 @@ export function BubbleTemplateAIChatModal({
   // provider reject it. Better than pre-blocking with a wrong guess.
   const chatProvider = useAiConfigStore((s) => s.chatProvider);
   const chatModel = useAiConfigStore((s) => s.chatModel);
-  const fetchedModels = useModelRegistryStore((s) => s.modelsByProvider[chatProvider] ?? []);
+  const fetchedModels = useModelRegistryStore((s) => s.modelsByProvider[chatProvider] ?? EMPTY_MODELS);
   const selectedModel = findModelInCatalog(chatProvider, chatModel) ?? fetchedModels.find((m) => m.id === chatModel);
   const visionOk = !selectedModel || isVisionModel(selectedModel);
 

--- a/apps/desktop/src/i18n/locales/en/pet.json
+++ b/apps/desktop/src/i18n/locales/en/pet.json
@@ -41,5 +41,20 @@
   },
   "bubble": {
     "closeAria": "Close"
+  },
+  "tabs": {
+    "chat": "Chat",
+    "actions": "Actions",
+    "inbox": "Inbox"
+  },
+  "inbox": {
+    "empty": "No notifications",
+    "clear": "Clear",
+    "kind": {
+      "info": "info",
+      "reminder": "reminder",
+      "message": "message",
+      "event": "event"
+    }
   }
 }

--- a/apps/desktop/src/i18n/locales/zh/pet.json
+++ b/apps/desktop/src/i18n/locales/zh/pet.json
@@ -41,5 +41,20 @@
   },
   "bubble": {
     "closeAria": "关闭"
+  },
+  "tabs": {
+    "chat": "对话",
+    "actions": "操作",
+    "inbox": "收件箱"
+  },
+  "inbox": {
+    "empty": "暂无通知",
+    "clear": "清空",
+    "kind": {
+      "info": "信息",
+      "reminder": "提醒",
+      "message": "消息",
+      "event": "事件"
+    }
   }
 }

--- a/apps/desktop/src/services/petNotifyDispatcher.ts
+++ b/apps/desktop/src/services/petNotifyDispatcher.ts
@@ -39,6 +39,11 @@ export function decideNotification(
  *  This is the entry point the main-window `pet://notify` listener calls. */
 export async function dispatchNotification(payload: PetBubblePayload): Promise<void> {
   if (!payload?.text) return;
+  // ponytail: capture every dispatched payload into the inbox regardless of
+  // routing (bubble / corner / off) — the inbox is the persistent record of
+  // what came in, separate from the ephemeral toast. Single chokepoint so
+  // every trigger source (HTTP, schedule, chat) lands here.
+  usePetStore.getState().addInboxItem(payload);
   const form = usePetStore.getState().notificationForm;
   const { bubble, corner } = decideNotification(form);
   if (bubble) {

--- a/apps/desktop/src/store/petStore.ts
+++ b/apps/desktop/src/store/petStore.ts
@@ -8,6 +8,20 @@ import {
   type Placement,
 } from '@/components/pet/petPosition';
 import type { BubbleTemplate } from '@/components/pet/bubbleTemplate';
+import type { PetBubblePayload } from '@/components/pet/PetBubbleApp';
+
+/** A received notification snapshot persisted to the inbox tab. `payload`
+ *  is the original `PetBubblePayload` so the inbox row can render the same
+ *  title/text/kind and re-fire the same jump on click. */
+export interface InboxItem {
+  id: string;
+  receivedAt: number;
+  payload: PetBubblePayload;
+}
+
+/** Cap on persisted inbox items. Older entries are dropped on add. Prevents
+ *  unbounded growth from a chatty source. */
+export const INBOX_MAX_ITEMS = 100;
 
 // ponytail: PET_SIZE_VERSION / PET_SIZE_DEFAULT / PET_SIZE_TO_PX / PetSize are
 // owned by petPosition.ts (the pure-math module). petStore imports them — this
@@ -55,6 +69,7 @@ export const PERSIST_KEYS_PET = [
   'bubbleUserTemplates',
   'bubbleActiveTemplateId',
   'bubbleAppWhitelist',
+  'inboxItems',
 ] as const;
 
 export interface PetState {
@@ -90,6 +105,9 @@ export interface PetState {
   bubbleActiveTemplateId: string;
   /** Whitelist of macOS app names approved for `launch.type = "app"`. */
   bubbleAppWhitelist: string[];
+  /** Persisted received-notification snapshots for the Inbox tab. Capped to
+   *  INBOX_MAX_ITEMS; newest first. */
+  inboxItems: InboxItem[];
 
   setPetModeEnabled: (enabled: boolean) => void;
   setPetPosition: (x: number, y: number) => void;
@@ -111,6 +129,9 @@ export interface PetState {
   setBubbleActiveTemplateId: (id: string) => void;
   addBubbleAppToWhitelist: (app: string) => void;
   removeBubbleAppFromWhitelist: (app: string) => void;
+  addInboxItem: (payload: PetBubblePayload) => void;
+  removeInboxItem: (id: string) => void;
+  clearInbox: () => void;
 
   /** Load this store's slice from the persisted `settings:all` blob. */
   hydrate: (blob: Record<string, unknown>) => void;
@@ -163,6 +184,7 @@ export const usePetStore = create<PetState>((set, get) => ({
   bubbleUserTemplates: [],
   bubbleActiveTemplateId: 'default',
   bubbleAppWhitelist: [],
+  inboxItems: [],
 
   setPetModeEnabled: (enabled) => { set({ petModeEnabled: enabled }); schedulePersist(); },
 
@@ -285,6 +307,33 @@ export const usePetStore = create<PetState>((set, get) => ({
   removeBubbleAppFromWhitelist: (app) => {
     const cur = get().bubbleAppWhitelist;
     set({ bubbleAppWhitelist: cur.filter((a) => a !== app) });
+    schedulePersist();
+  },
+
+  addInboxItem: (payload) => {
+    // ponytail: snapshot the payload as-is so the inbox row renders the same
+    // title/text/kind and re-fires the same jump on click. Cap to
+    // INBOX_MAX_ITEMS, dropping the oldest — a chatty source shouldn't grow
+    // storage unbounded. Newest first (index 0 = most recent).
+    const item: InboxItem = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      receivedAt: Date.now(),
+      payload,
+    };
+    const cur = get().inboxItems;
+    const next = [item, ...cur].slice(0, INBOX_MAX_ITEMS);
+    set({ inboxItems: next });
+    schedulePersist();
+  },
+
+  removeInboxItem: (id) => {
+    set({ inboxItems: get().inboxItems.filter((i) => i.id !== id) });
+    schedulePersist();
+  },
+
+  clearInbox: () => {
+    if (get().inboxItems.length === 0) return;
+    set({ inboxItems: [] });
     schedulePersist();
   },
 
@@ -416,6 +465,25 @@ export const usePetStore = create<PetState>((set, get) => ({
     } else {
       saved.bubbleAppWhitelist = saved.bubbleAppWhitelist.filter(
         (a: unknown): a is string => typeof a === 'string',
+      );
+    }
+
+    // Coerce `inboxItems` to InboxItem[]. Drop entries missing id/receivedAt
+    // or with a non-object payload — a corrupt blob shouldn't fail the whole
+    // hydrate. `payload.text` is the only required field on PetBubblePayload,
+    // so require it for kept entries.
+    if (!Array.isArray(saved.inboxItems)) {
+      saved.inboxItems = [];
+    } else {
+      saved.inboxItems = saved.inboxItems.filter(
+        (i: unknown): i is InboxItem => {
+          if (typeof i !== 'object' || i === null) return false;
+          const o = i as Record<string, unknown>;
+          return typeof o.id === 'string' &&
+            typeof o.receivedAt === 'number' &&
+            typeof o.payload === 'object' && o.payload !== null &&
+            typeof (o.payload as { text?: unknown }).text === 'string';
+        },
       );
     }
 


### PR DESCRIPTION
Records every dispatched `pet://notify` payload into petStore.inboxItems (capped at 100, persisted to settings:all). New PetInbox component renders the list in a third pet-panel tab; clicking a row re-fires the same pet://bubble-action jump the bubble window emits on title-click.

Cross-window sync: main window's addInboxItem triggers schedulePersist → pet://settings-updated. PetPanelApp now listens for that event (mirrors PetBubbleApp / PetCornerApp) and calls hydrateAllStores so the panel's own petStore instance picks up new items — without this the Inbox tab stayed empty because the panel never saw the main window's write.

Also fixes a pre-existing infinite-loop in BubbleTemplateAIChatModal's `useModelRegistryStore((s) => s.modelsByProvider[chatProvider] ?? [])` selector — the inline `[]` returned a new reference on every call, which zustand v5 + React 18 useSyncExternalStore treated as a store mutation. Replaced with a stable EMPTY_MODELS constant (same pattern as the file's existing EMPTY_MESSAGES).

i18n: added pet:tabs.{chat,actions,inbox} and pet:inbox.* keys (en/zh); wired PetPanelApp's three tab labels and PetInbox's empty/clear/kind labels through useTranslation.